### PR TITLE
Fix document generator script to download md2html v2

### DIFF
--- a/publish-documentation/action-scripts/generate-single-page-doc.sh
+++ b/publish-documentation/action-scripts/generate-single-page-doc.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 
-go install github.com/nocd5/md2html@latest
+
+GO111MODULE=on go get github.com/nocd5/md2html@v2.0.0
 
 md2html -e -t $LIST_OF_PATHS_TO_MARKDOWN_FILES \
 -c $PATH_TO_CSS_FILE \

--- a/publish-documentation/action-scripts/generate-single-page-doc.sh
+++ b/publish-documentation/action-scripts/generate-single-page-doc.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 
-
+# this is a workaround to explicitily state version wanted, more info here: https://maelvls.dev/go111module-everywhere/
+# do not use `go install github.com/nocd5/md2html@latest` as this will install incorrect version
 GO111MODULE=on go get github.com/nocd5/md2html@v2.0.0
 
 md2html -e -t $LIST_OF_PATHS_TO_MARKDOWN_FILES \


### PR DESCRIPTION
`go install github.com/nocd5/md2html@latest` apparently installs v1.2.0 instead of actual latest for some reason.

```
Run /home/runner/work/_actions/detroit-labs/labs-cloud-actions/main/publish-documentation/action-scripts/generate-single-page-doc.sh
go: downloading github.com/nocd5/md2html v1.2.0
```

The workaround is to explicitly state the version (which requires that setting the environment variable GO111MODULE=on)

More info here: https://maelvls.dev/go111module-everywhere/