### PR TITLE
Added mjs file type support to node nginx config

### DIFF
--- a/build-and-push-node-application/action-scripts/nginx.conf
+++ b/build-and-push-node-application/action-scripts/nginx.conf
@@ -36,6 +36,12 @@ http {
   server {
     listen      8080 default_server;
     server_name _;
+    
+    include mime.types;
+    types 
+    {
+      application/javascript mjs;
+    }
 
     if ($http_x_forwarded_proto = "http") {
        return 308 https://$host$request_uri;


### PR DESCRIPTION
### What does this PR do? :soccer:
This PR updates the node application nginx config to use the `application/javascript` MIME type for *.mjs files (node JS module file). This is being added to support applications (i.e. Storybook 7) that use this file type/extension.

Reference: https://semisignal.com/serving-mjs-files-with-nginx/

### How can this PR be tested? :mag:
Not sure. Once it is merged, we can re-deploy storybook from the `detroit-labs/jjs-web-frontend` project and no longer see MIME type errors in the JS console: https://jj-test-storybook.detroitlabs.com