### PR TITLE
Bump Google Cloud and Gradle action versions

### DIFF
--- a/build-and-push-node-application/action.yaml
+++ b/build-and-push-node-application/action.yaml
@@ -63,7 +63,7 @@ runs:
       with:
         credentials_json: ${{ inputs.gcloud-service-auth }}
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v1
+      uses: google-github-actions/setup-gcloud@v2
       with:
         install_components: 'gke-gcloud-auth-plugin'
     - name: Authorize Docker push

--- a/build-and-push-spring-boot-application/action.yaml
+++ b/build-and-push-spring-boot-application/action.yaml
@@ -49,7 +49,7 @@ runs:
       with:
         credentials_json: ${{ inputs.gcloud-service-auth }}
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v1
+      uses: google-github-actions/setup-gcloud@v2
       with:
         install_components: 'gke-gcloud-auth-plugin'
     - name: Authorize Docker push

--- a/build-and-push-spring-boot-application/action.yaml
+++ b/build-and-push-spring-boot-application/action.yaml
@@ -37,7 +37,7 @@ runs:
       shell: bash
       name: Generate the name of the docker image
       id: generate-image-name
-    - uses: gradle/gradle-build-action@v2
+    - uses: gradle/actions/setup-gradle@v3
       name: Build Docker Container
       with:
         arguments: |

--- a/build-and-push-swagger-application/action.yaml
+++ b/build-and-push-swagger-application/action.yaml
@@ -45,7 +45,7 @@ runs:
       with:
         credentials_json: ${{ inputs.gcloud-service-auth }}
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v1
+      uses: google-github-actions/setup-gcloud@v2
       with:
         install_components: 'gke-gcloud-auth-plugin'
     - name: Authorize Docker push

--- a/publish-documentation/action.yaml
+++ b/publish-documentation/action.yaml
@@ -46,7 +46,7 @@ runs:
       with:
         credentials_json: ${{ inputs.gcloud-service-auth }}
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v1
+      uses: google-github-actions/setup-gcloud@v2
     - name: Upload generated single page documentation (aggregate of all specified mark down files)
       uses: google-github-actions/upload-cloud-storage@v1
       with:


### PR DESCRIPTION
### What does this PR do? :soccer:
This PR bumps the major version of the setup-gcloud GitHub Actions dependency. The current version, v1, [consistently produces warnings](https://github.com/detroit-labs/jjs-web-frontend/actions/runs/12014668724) saying the workflow will be forced to run on Node.js 20. By bumping setup-gcloud to v2, this warning should be removed.

This PR also bumps the gradle-build-action GitHub Actions dependency to v3 ([Node.js 20-compatible](https://github.com/gradle/actions/blob/v3.5.0/setup-gradle/action.yml)) while using its preferred name. See the [existing repo/README](https://github.com/gradle/gradle-build-action) for more on the preferred action to use, as well as the [repo for the superseding setup-gradle workflow](https://github.com/gradle/actions)). (v4 is available for the setup-gradle workflow, but it is a [breaking change](https://github.com/gradle/actions/releases/tag/v4.0.0) for how we currently use it.) This should also help remove the [Node.js 20 warnings](https://github.com/detroit-labs/jjs-web-backend/actions/runs/12015499336) in the JJ's Web backend GitHub Actions workflow runs.

### Tell me about any important implementation details. :construction:
If this PR is approved and merged, it may be smart to publish a release for labs-cloud-actions so that the downstream jjs-web-frontend repo (and also jjs-web-backend repo) can see fewer warnings in its workflow runs. The jjs-web-frontend repo is bumping to Node.js 20 as of PR detroit-labs/jjs-web-frontend#865, but it may be wise to check in on other projects using labs-cloud-actions to confirm they can use Node.js 20 as well.

Security support for Node.js 18 is [ending in 5 months](https://endoflife.date/nodejs), and support has long since ended for Node.js 16.