### PR TITLE
Remove deprecated arguments parameter for setup-gradle, run matching gradle command below instead

### DIFF
--- a/build-and-push-spring-boot-application/action.yaml
+++ b/build-and-push-spring-boot-application/action.yaml
@@ -38,7 +38,7 @@ runs:
       name: Generate the name of the docker image
       id: generate-image-name
     - name: Set Up Gradle
-      uses: gradle/actions/setup-gradle@v3
+      uses: gradle/actions/setup-gradle@v4
     - name: Build Docker Container
       run: |
         ./gradlew \

--- a/build-and-push-spring-boot-application/action.yaml
+++ b/build-and-push-spring-boot-application/action.yaml
@@ -37,12 +37,13 @@ runs:
       shell: bash
       name: Generate the name of the docker image
       id: generate-image-name
-    - uses: gradle/actions/setup-gradle@v3
-      name: Build Docker Container
-      with:
-        arguments: |
-          ${{ inputs.gradle-module-name }}:clean
-          ${{ inputs.gradle-module-name }}:bootBuildImage
+    - name: Set Up Gradle
+      uses: gradle/actions/setup-gradle@v3
+    - name: Build Docker Container
+      run: |
+        ./gradlew \
+          ${{ inputs.gradle-module-name }}:clean \
+          ${{ inputs.gradle-module-name }}:bootBuildImage \
           --imageName=${{steps.generate-image-name.outputs.IMAGE_NAME}}:${{ github.sha }}
     - uses: google-github-actions/auth@v2
       name: Login to Google Cloud


### PR DESCRIPTION
### What does this PR do? :soccer:
This PR updates the Spring Boot action so that its use of the [setup-gradle action](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md) does not use a deprecated `arguments` parameter. Instead, the setup-gradle action is used, and then a Gradle command is run below it.

### Tell me about any important implementation details. :construction:
I used the [deprecation upgrade guide](https://github.com/gradle/actions/blob/v4.0.0-rc.1/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated) for the setup-gradle action to inform the change in this PR. We're using setup-gradle@v3 as of merging #37 and releasing, but if we want to bump to v4 in the future, we'll have to drop the `arguments` parameter while using this action. v3 marked this parameter as deprecated (hence [warnings](https://github.com/detroit-labs/jjs-web-backend/actions/runs/12015499336)), and v4 will remove it altogether.

We've seen some success in removing `arguments` from setup-gradle on JJ's Web backend workflows. After merging detroit-labs/jjs-web-backend#424, we saw warnings change from [Node.js deprecation](https://github.com/detroit-labs/jjs-web-backend/actions/runs/12034744401) to [action parameter deprecation](https://github.com/detroit-labs/jjs-web-backend/actions/runs/12034744401). After merging detroit-labs/jjs-web-backend#425, which [removed `arguments`](https://github.com/detroit-labs/jjs-web-backend/pull/425/commits/d400b7411d0fe9d23274b3b8b3589a6f89c6afa2), we saw [one fewer deprecation warning](https://github.com/detroit-labs/jjs-web-backend/actions/runs/12051846849). (The remaining warning comes from invoking `build-and-push-spring-boot-application`. 😉)

My hope is, if we review and merge this PR, then release (probably a patch/minor version?), future JJ's Web backend workflow runs should have zero deprecation warnings of this flavor. 🙏🏻 

### How can this PR be tested? :mag:
- Confirm the changed workflow step is functionally equivalent, and confirm its syntax is valid, sensible YAML.