### PR TITLE
Fix: Provide missing 'shell: bash' configuration to build docker container workflow step

### DIFF
--- a/build-and-push-spring-boot-application/action.yaml
+++ b/build-and-push-spring-boot-application/action.yaml
@@ -40,6 +40,7 @@ runs:
     - name: Set Up Gradle
       uses: gradle/actions/setup-gradle@v4
     - name: Build Docker Container
+      shell: bash
       run: |
         ./gradlew \
           ${{ inputs.gradle-module-name }}:clean \


### PR DESCRIPTION
### What does this PR do? :soccer:
We recently merged a [PR for JJ's Web BE](https://github.com/detroit-labs/jjs-web-backend/pull/427), and I was eager to see its workflow run results since it should have referenced the newly updated labs-cloud-actions/build-and-push-spring-boot-application action. In #38, we removed the deprecated `arguments` parameter to the setup-gradle action and supplied the next workflow step with Gradle commands to run, while also updating setup-gradle to v4. However, it seems that GitHub Actions was [not pleased with this change](https://github.com/detroit-labs/jjs-web-backend/actions/runs/12186555628). 😧 In particular, it is complaining about a missing required property named `shell`. I must have overlooked this when breaking out Gradle commands to a separate workflow step [as recommended by the deprecation upgrade guide](https://github.com/gradle/actions/blob/v4.2.1/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated). (Though, to be fair to myself, their deprecation upgrade guide did not call out `shell` as required. Maybe it's that the Gradle commands we run reference workflow inputs/environment variables unlike the simple examples in their docs? 🤔)

In any case, this PR attempts to fix the issue by adding `shell: bash` to the build-and-push-spring-boot-application workflow step that runs the Gradle commands broken out in #38. This at least sets up that workflow step the same way as some other Docker steps below it.

### How can this PR be tested? :mag:
Please double check the YAML syntax and compare the changed workflow step to its siblings below it. Does everything seem sensible?

If this PR is approved and merged, I might recommend a patch release for labs-cloud-actions to address the workflow failure encountered on the JJ's project. I found that this workflow error [also adversely affected a manual run for a backend deployment](https://github.com/detroit-labs/jjs-web-backend/actions/runs/12189206614). 😓  Something something omelette and broken eggs.