### PR TITLE
Bump third-party actions to latest major versions

### DIFF
--- a/build-and-push-node-application/action.yaml
+++ b/build-and-push-node-application/action.yaml
@@ -30,7 +30,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       name: Install Node
       with:
         node-version-file: '.nvmrc'
@@ -58,12 +58,12 @@ runs:
       run: |-
         docker build --build-arg NGINX_CONFIG_PATH="${NGINX_CONFIG_PATH}" -t ${{ steps.generate-image-name.outputs.IMAGE_NAME }}:${{ github.sha }} -f "${DOCKER_FILE_PATH}" .
         docker tag ${{ steps.generate-image-name.outputs.IMAGE_NAME }}:${{ github.sha }} ${{ steps.generate-image-name.outputs.IMAGE_NAME }}:latest
-    - uses: google-github-actions/auth@v2
+    - uses: google-github-actions/auth@v3
       name: Login to Google Cloud
       with:
         credentials_json: ${{ inputs.gcloud-service-auth }}
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@v3
       with:
         install_components: 'gke-gcloud-auth-plugin'
     - name: Authorize Docker push

--- a/build-and-push-spring-boot-application/action.yaml
+++ b/build-and-push-spring-boot-application/action.yaml
@@ -28,7 +28,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       name: Install Java
       with:
         distribution: temurin
@@ -38,7 +38,7 @@ runs:
       name: Generate the name of the docker image
       id: generate-image-name
     - name: Set Up Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v5
     - name: Build Docker Container
       shell: bash
       run: |
@@ -46,12 +46,12 @@ runs:
           ${{ inputs.gradle-module-name }}:clean \
           ${{ inputs.gradle-module-name }}:bootBuildImage \
           --imageName=${{steps.generate-image-name.outputs.IMAGE_NAME}}:${{ github.sha }}
-    - uses: google-github-actions/auth@v2
+    - uses: google-github-actions/auth@v3
       name: Login to Google Cloud
       with:
         credentials_json: ${{ inputs.gcloud-service-auth }}
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@v3
       with:
         install_components: 'gke-gcloud-auth-plugin'
     - name: Authorize Docker push

--- a/build-and-push-swagger-application/action.yaml
+++ b/build-and-push-swagger-application/action.yaml
@@ -40,12 +40,12 @@ runs:
         RELATIVE_SPEC_FILE_PATH: ${{ inputs.spec-file-path }}
         DOCKER_IMAGE: ${{ steps.generate-image-name.outputs.IMAGE_NAME }}
         GIT_SHA: ${{ github.sha }}
-    - uses: google-github-actions/auth@v2
+    - uses: google-github-actions/auth@v3
       name: Login to Google Cloud
       with:
         credentials_json: ${{ inputs.gcloud-service-auth }}
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@v3
       with:
         install_components: 'gke-gcloud-auth-plugin'
     - name: Authorize Docker push

--- a/post-job-status-slack/action.yaml
+++ b/post-job-status-slack/action.yaml
@@ -32,7 +32,7 @@ jobs:
       
     - name: Send GitHub Action trigger data to Slack workflow
       id: slack
-      uses: slackapi/slack-github-action@v1.22.0
+      uses: slackapi/slack-github-action@v3
       with:
        payload: |
         {

--- a/publish-documentation/action.yaml
+++ b/publish-documentation/action.yaml
@@ -30,7 +30,7 @@ runs:
   using: "composite"
   steps:
     - name: Install and set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ inputs.go-version }}
     - name: Generate single page HTML documentation
@@ -42,13 +42,13 @@ runs:
         PAGE_TITLE: ${{ inputs.documentation-page-title }}
         DOCUMENTATION_FILE_NAME: ${{ inputs.documentation-file-storage-name }}
     - name: Login to Google Cloud
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: ${{ inputs.gcloud-service-auth }}
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@v3
     - name: Upload generated single page documentation (aggregate of all specified mark down files)
-      uses: google-github-actions/upload-cloud-storage@v1
+      uses: google-github-actions/upload-cloud-storage@v3
       with:
         headers: |-
           content-type: text/html

--- a/update-gke-deployment/action.yaml
+++ b/update-gke-deployment/action.yaml
@@ -33,13 +33,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: google-github-actions/auth@v2
+    - uses: google-github-actions/auth@v3
       name: Login to Google Cloud
       with:
         credentials_json: ${{ inputs.gcloud-service-auth }}
     - name: Fetch k8s cluster credentials
       id: get-credentials
-      uses: google-github-actions/get-gke-credentials@v1
+      uses: google-github-actions/get-gke-credentials@v3
       with:
         cluster_name: ${{ inputs.cluster-name }}
         location: ${{ inputs.deployment-location }}


### PR DESCRIPTION
### Issue Link :link:

This issue is not on an LCP Jira board, but it is related to the following work for the Jimmy John's website:

https://detroitlabs.jira.com/browse/JJWS-2980

### What does this PR do? :soccer:

This PR bumps the major versions of third-party actions referenced by `labs-cloud-actions` workflows. Compare to previous PRs #34 and #37 that made similar changes. 🙂 

The screenshot below is from a [recently run JJ's action](https://github.com/detroit-labs/jjs-web-frontend/actions/runs/23068063196), but it illustrates the need for an eventual upgrade to both `jjs-web-frontend` GitHub Actions workflows and `labs-cloud-actions` workflows we depend on. 

<img width="809" height="576" alt="Screenshot 2026-03-13 at 16 26 21" src="https://github.com/user-attachments/assets/0547ca56-1516-431a-a442-a5b17f6a9122" />

Similar to the change in #37 to support Node.js 20 compatibility, GitHub Actions will require all workflows running on it to be compatible with Node.js 24 by June of this year. I found the latest major versions of the third-party actions referenced in this repo are Node.js 24-compatible. The notable changes from the most recent releases of third-party actions mostly focus on Node.js 24 compatibility.

Release notes of updated third-party actions (in order of appearance in this PR), along with the version bump:
- [`actions/setup-node`](https://github.com/actions/setup-node/releases): v4 -> v6
- [`google-github-actions/auth`](https://github.com/google-github-actions/auth/releases): v2 -> v3
- [`google-github-actions/setup-gcloud`](https://github.com/google-github-actions/setup-gcloud/releases): v2 -> v3
- [`actions/setup-java`](https://github.com/actions/setup-java/releases): v4 -> v5
- [`gradle/actions/setup-gradle`](https://github.com/gradle/actions/releases): v4 -> v5
- [`slackapi/slack-github-action`](https://github.com/slackapi/slack-github-action/releases): v1.2.2 -> v3
- [`actions/setup-go`](https://github.com/actions/setup-go/releases): v4 -> v6
- [`google-github-actions/upload-cloud-storage`](https://github.com/google-github-actions/upload-cloud-storage/releases): v1 -> v3
- [`google-github-actions/get-gke-credentials`](https://github.com/google-github-actions/get-gke-credentials/releases): v1 -> v3

💡 I recommend we release a new major version of `labs-cloud-actions` if this PR is merged (`v4.0.0`), similar to our approach for [release 2.0.0](https://github.com/detroit-labs/labs-cloud-actions/releases/tag/v2.0.0) and [release 3.0.0](https://github.com/detroit-labs/labs-cloud-actions/releases/tag/v3.0.0). 

### How can this PR be tested? :mag:

I can't think of formal testing steps, but I can offer the [output of a recent manual deployment workflow run for JJ's](https://github.com/detroit-labs/jjs-web-frontend/actions/runs/23267043937). The `jjs-web-frontend` branch I ran with the manual deployment workflow [references the compare branch of this PR](https://github.com/detroit-labs/jjs-web-frontend/pull/1233/changes/a75fa78bfa9b7e3b6abf4753ff6cd246dc783147) to `labs-cloud-actions`. With the [changes I've made to JJ's actions](https://github.com/detroit-labs/jjs-web-frontend/pull/1233) and the changes in this PR compare branch, there are no more Node.js 24 warnings in the workflow run output. 😌

<img width="1472" height="1139" alt="Screenshot 2026-03-19 at 11 17 00" src="https://github.com/user-attachments/assets/217e16bf-7bce-4038-9e34-f670dc5ccd5d" />